### PR TITLE
Added gdrive link to WR38 imagenet weights

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ We've included pre-trained models. Download checkpoints to a folder `pretrained_
 * [pretrained_models/sdc_cityscapes_vrec.pth.tar](https://drive.google.com/file/d/1OxnJo2tFEQs3vuY01ibPFjn3cRCo2yWt/view?usp=sharing)[38MB]
 * [pretrained_models/FlowNet2_checkpoint.pth.tar](https://drive.google.com/file/d/1hF8vS6YeHkx3j2pfCeQqqZGwA_PJq_Da/view?usp=sharing)[620MB]
 
+Imagenet Weights
+* [pretrained_models/wider_resnet38.pth.tar](https://drive.google.com/file/d/1OfKQPQXbXGbWAQJj2R82x6qyz6f-1U6t/view?usp=sharing)[833MB]
 
 ## Data Loaders
 


### PR DESCRIPTION
This can be used to train Mapillary or Cityscapes for people who want to train from scratch.