### PR TITLE
fix resume bug

### DIFF
--- a/train.py
+++ b/train.py
@@ -165,7 +165,7 @@ def main():
 
     net = network.warp_network_in_dataparallel(net, args.apex)
     if args.snapshot:
-        optimizer.load_weights(net, optimizer,
+        optimizer.load_weights(net, optim,
                                args.snapshot, args.restore_optimizer)
 
     torch.cuda.empty_cache()


### PR DESCRIPTION
The naming is confused. We should pass in the real optimizer instead of the file `optimizer.py`. Change optimizer to optim will resolve the issue.