### PR TITLE
Add two models

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ We've included pre-trained models. Download checkpoints to a folder `pretrained_
 ImageNet Weights
 * [pretrained_models/wider_resnet38.pth.tar](https://drive.google.com/file/d/1OfKQPQXbXGbWAQJj2R82x6qyz6f-1U6t/view?usp=sharing)[833MB]
 
+Other Weights
+* [pretrained_models/cityscapes_cv0_seresnext50_nosdcaug.pth](https://drive.google.com/file/d/1aGdA1WAKKkU2y-87wSOE1prwrIzs_L-h/view?usp=sharing)[324MB]
+* [pretrained_models/cityscapes_cv0_wideresnet38_nosdcaug.pth](https://drive.google.com/file/d/1CKB7gpcPLgDLA7LuFJc46rYcNzF3aWzH/view?usp=sharing)[1.1GB]
+
 ## Data Loaders
 
 Dataloaders for Cityscapes, Mapillary, Camvid and Kitti are available in [datasets](./datasets). Details of preparing each dataset can be found at [PREPARE_DATASETS.md](https://github.com/NVIDIA/semantic-segmentation/blob/master/PREPARE_DATASETS.md) <br />


### PR DESCRIPTION
This PR adds two pre-trained models for Cityscapes dataset. One is using SEResNeXt50 as backbone, the other is using WideResNet38 as backbone. Both models are trained using standard train/val split in Cityscapes. Both models are trained using border relaxation technique, but didn't use extra SDCNet augmented data.