### PR TITLE
reduce size of Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,21 @@
 FROM nvcr.io/nvidia/pytorch:19.10-py3
 
-RUN pip install runx==0.0.6
-RUN pip install numpy
-RUN pip install sklearn
-RUN pip install h5py
-RUN pip install jupyter
-RUN pip install scikit-image
-RUN pip install pillow
-RUN pip install piexif
-RUN pip install cffi
-RUN pip install tqdm
-RUN pip install dominate
-RUN pip install opencv-python
-RUN pip install nose
-RUN pip install ninja
+RUN pip install --no-cache-dir runx==0.0.6
+RUN pip install --no-cache-dir numpy
+RUN pip install --no-cache-dir sklearn
+RUN pip install --no-cache-dir h5py
+RUN pip install --no-cache-dir jupyter
+RUN pip install --no-cache-dir scikit-image
+RUN pip install --no-cache-dir pillow
+RUN pip install --no-cache-dir piexif
+RUN pip install --no-cache-dir cffi
+RUN pip install --no-cache-dir tqdm
+RUN pip install --no-cache-dir dominate
+RUN pip install --no-cache-dir opencv-python
+RUN pip install --no-cache-dir nose
+RUN pip install --no-cache-dir ninja
 
-RUN apt-get update
-RUN apt-get install libgtk2.0-dev -y && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install libgtk2.0-dev -y && rm -rf /var/lib/apt/lists/*
 
 # Install Apex
 RUN cd /home/ && git clone https://github.com/NVIDIA/apex.git apex && cd apex && python setup.py install --cuda_ext --cpp_ext


### PR DESCRIPTION
This pull request proposes the following changes:

- use `pip install --no-cache-dir` to disable caching
- place `apt-get update` in the same `RUN` instruction with `rm -rf /var/lib/apt/lists/*`, so that apt caches do not count towards image size.