### PR TITLE
Fix mask generation in base_loader when reading an image

### DIFF
--- a/datasets/base_loader.py
+++ b/datasets/base_loader.py
@@ -173,9 +173,9 @@ class BaseLoader(data.Dataset):
         if (mask_out):
             mask = self.drop_mask * mask
 
-        mask = mask.copy()
+        mask_copy = mask.copy()
         for k, v in self.id_to_trainid.items():
-            binary_mask = (mask == k) #+ (gtCoarse == k)
+            binary_mask = (mask_copy == k) #+ (gtCoarse == k)
             if ('refinement' in mask_path) and cfg.DROPOUT_COARSE_BOOST_CLASSES != None and v in cfg.DROPOUT_COARSE_BOOST_CLASSES and binary_mask.sum() > 0 and 'vidseq' not in mask_path:
                 binary_mask += (gtCoarse == k)
                 binary_mask[binary_mask >= 1] = 1


### PR DESCRIPTION
This pull request proposes a bug fix. In base_loader.py, the read_images function generates a mask without checking keys in an original copy. This causes problems on some datasets where mask values are incorrectly replaced. The change would make the mask generation in the base_loader.py match the method used in uniform.py. https://github.com/NVIDIA/semantic-segmentation/blob/7726b144c2cc0b8e09c67eabb78f027efdf3f0fa/datasets/base_loader.py#L176-L178 https://github.com/NVIDIA/semantic-segmentation/blob/7726b144c2cc0b8e09c67eabb78f027efdf3f0fa/datasets/uniform.py#L112-L115